### PR TITLE
Added FrameDifferenc(FilterEquals) node that filter equal frames

### DIFF
--- a/VL.OpenCV.AddFrameDifference.vl
+++ b/VL.OpenCV.AddFrameDifference.vl
@@ -1,0 +1,169 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="OR2wMl0nuI4Oo47HIwC6rd" LanguageVersion="2024.6.6" Version="0.128">
+  <NugetDependency Id="KqOdzQOmo0lMuUT0T4TJjw" Location="VL.CoreLib" Version="2024.6.6" />
+  <Patch Id="RKXKvOhI9e9ORbWG8FETWt">
+    <Canvas Id="PiUUzShRqfTL4rfhGc7mNp" DefaultCategory="Main" CanvasType="FullCategory">
+      <Canvas Id="H2XnnfQL8iSMbmmzOXXhzq" Name="Filter" Position="284,334">
+        <!--
+
+    ************************ FrameDifference (FilterEquals) ************************
+
+-->
+        <Node Name="FrameDifference (FilterEquals)" Bounds="317,320" Id="PnJoaV8AUqxNOMTfSdfXGq">
+          <p:NodeReference>
+            <Choice Kind="ContainerDefinition" />
+          </p:NodeReference>
+          <Patch Id="QcZbcnInPhgQYr18vigkV3">
+            <Canvas Id="NLPnLsW1USrPttQKOsyhJQ" CanvasType="Group">
+              <ControlPoint Id="MXrstwyY6wjLU0DXmElwRj" Bounds="138,44" />
+              <ControlPoint Id="NvTklT8DHr7ODHHXoygUhf" Bounds="139,498" />
+              <ControlPoint Id="Eti8avnzVKKMMq6hmpYfGY" Bounds="580,48" />
+              <Node Bounds="129,363,303,78" Id="N2xhuUIehoIMPFYGIPgJKn">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                </p:NodeReference>
+                <Pin Id="MurTNb5jVAbQbgo40TZSTB" Name="Condition" Kind="InputPin" />
+                <Patch Id="Ja3fgf13cGkMNNz2lguBc9" ManuallySortedPins="true">
+                  <Patch Id="KU5I03EtS5yOQIZMXz1Y23" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="IodlfbWarhvLkEFV3Br4xd" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="195,391,91,19" Id="ThUwUys8iM8MBFPdI1ytvY">
+                    <p:NodeReference LastCategoryFullName="OpenCV.Filter" LastDependency="VL.OpenCV.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="Category" Name="OpenCV" />
+                      <Choice Kind="ProcessAppFlag" Name="FrameDifference" />
+                    </p:NodeReference>
+                    <Pin Id="PYJBHgEKCIfQIGNuEi5uM5" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                    <Pin Id="FkSNZhXiHArNbEO6GhkvkD" Name="Input" Kind="InputPin" />
+                    <Pin Id="FrqUYfTotWvL0UDtk9dW2C" Name="Apply" Kind="InputPin" />
+                    <Pin Id="VWE5PqHyLNVLGo8AlCzAtS" Name="Output" Kind="OutputPin" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="UzLconvNfdWP3vmu90EClF" Bounds="143,369" Alignment="Top" />
+                <ControlPoint Id="RiDQHeSMrHtLddjxvamTX8" Bounds="143,435" Alignment="Bottom" />
+                <ControlPoint Id="S5Krt8cgq8cNTYU0Clt6KA" Bounds="415,369" Alignment="Top" />
+                <ControlPoint Id="VQI7RSLrwn2M4Gk5VBsJLp" Bounds="357,435" Alignment="Bottom" />
+              </Node>
+              <ControlPoint Id="NzrqkfKMU4BQaS518uQsr1" Bounds="440,48" />
+              <Node Bounds="96,118,253,153" Id="DYXovoDZhOzN4UZX6oxt6F">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                </p:NodeReference>
+                <Pin Id="MjkdkCVc4HDMXZEFqVD2QB" Name="Condition" Kind="InputPin" />
+                <Patch Id="CsMJVS2nAjsMyyjn6aOKd3" ManuallySortedPins="true">
+                  <Patch Id="LAjQN6hh5WBQKdtD0YY3JX" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="AhmbCzrktmzNglSmDzQD3f" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="140,149,197,96" Id="BQ4vMDemRl3MtlrNsqaHpF">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                      <CategoryReference Kind="Category" Name="Primitive" />
+                      <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                    </p:NodeReference>
+                    <Pin Id="Ogw8QOJqsAZOdLWB98UHfL" Name="Force" Kind="InputPin" />
+                    <Pin Id="JYv6ncDpZ85PgPx45FTdEp" Name="Dispose Cached Outputs" Kind="InputPin" />
+                    <Pin Id="KOYaQ0VPFs1NxNqfL6xbhN" Name="Has Changed" Kind="OutputPin" />
+                    <Patch Id="Ilg8zf3WGW3My6tvTQWzs1" ManuallySortedPins="true">
+                      <Patch Id="Nj4cc2Y1KUzOgONrNWOebU" Name="Create" ManuallySortedPins="true" />
+                      <Patch Id="LzbzT3h90UfP2f4KTMTkHW" Name="Then" ManuallySortedPins="true" />
+                      <Node Bounds="195,188,91,19" Id="NDSsZpWuwamQQfhevK9dvE">
+                        <p:NodeReference LastCategoryFullName="OpenCV.Filter" LastDependency="VL.OpenCV.vl">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <CategoryReference Kind="Category" Name="OpenCV" />
+                          <Choice Kind="ProcessAppFlag" Name="FrameDifference" />
+                        </p:NodeReference>
+                        <Pin Id="U5ZfRG8Af53MD4kH222aV1" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                        <Pin Id="BzRXHU6EWoDLCn1TtwUruJ" Name="Input" Kind="InputPin" />
+                        <Pin Id="QBWNM61tJtSL6nCpRYyKUi" Name="Apply" Kind="InputPin" />
+                        <Pin Id="EhNDjnbLgMmLn9LnqxWke5" Name="Output" Kind="OutputPin" />
+                      </Node>
+                    </Patch>
+                    <ControlPoint Id="AF5XVch4mRIMXgWyQ0yTCH" Bounds="152,155" Alignment="Top" />
+                    <ControlPoint Id="LC9zLM0OO79MBCz7ynTNxg" Bounds="153,239" Alignment="Bottom" />
+                    <ControlPoint Id="L2EPooqm9JzPHU9cAawaBD" Bounds="321,155" Alignment="Top" />
+                  </Node>
+                </Patch>
+                <ControlPoint Id="EkzsKLp8hg0OvNn5mIWloI" Bounds="139,124" Alignment="Top" />
+                <ControlPoint Id="Uyrw0UhJJgUOlcI61N0JBo" Bounds="140,265" Alignment="Bottom" />
+              </Node>
+              <Node Bounds="58,317,37,19" Id="ApSoC8KgETBLbCFWOldsbT">
+                <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="NOT" />
+                </p:NodeReference>
+                <Pin Id="R4IzBOCOnMUMrJvFv5BSqy" Name="Input" Kind="StateInputPin" />
+                <Pin Id="NXvFxt07F8oOBlmJ3SbFwo" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <ControlPoint Id="TvZSvp1aPkvPZje6qyoZwL" Bounds="392,296" />
+            </Canvas>
+            <Patch Id="MqoN4b2rumwOQI3n4rWey0" Name="Create" />
+            <Patch Id="TY8QM9kAV3FPuLqhNGCR4J" Name="Update">
+              <Pin Id="EPEnYeCq29fNFhFxH8tIjR" Name="Input" Kind="InputPin" />
+              <Pin Id="UoogGr6S02uQRLvp6wqI2x" Name="Output" Kind="OutputPin" />
+              <Pin Id="FiUJQUpXmLzPioaUJ4j9ty" Name="FilterSameFrames" Kind="InputPin" DefaultValue="True" Visibility="Optional">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Boolean" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="DQFGopFTMauPP9upbX88BG" Name="Apply" Kind="InputPin" DefaultValue="True">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Boolean" />
+                </p:TypeAnnotation>
+              </Pin>
+            </Patch>
+            <ProcessDefinition Id="EzQgw0UD2PoNx0N1YDYBMd">
+              <Fragment Id="P8wXBX0U7DiLXe9f9NbWRC" Patch="MqoN4b2rumwOQI3n4rWey0" Enabled="true" />
+              <Fragment Id="ADIsGnwab6HNYFLiNHNX9A" Patch="TY8QM9kAV3FPuLqhNGCR4J" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="TrYFugzx7CzPLO6aSts0yV" Ids="EPEnYeCq29fNFhFxH8tIjR,MXrstwyY6wjLU0DXmElwRj" IsHidden="true" />
+            <Link Id="DfHcOvVXV8xLtypC2s3lt9" Ids="NvTklT8DHr7ODHHXoygUhf,UoogGr6S02uQRLvp6wqI2x" IsHidden="true" />
+            <Link Id="UDw9KJDpGFrLMr5IeOzX2B" Ids="DQFGopFTMauPP9upbX88BG,Eti8avnzVKKMMq6hmpYfGY" IsHidden="true" />
+            <Link Id="LWGXjrlsKmjO1XL1fOHH4z" Ids="Eti8avnzVKKMMq6hmpYfGY,L2EPooqm9JzPHU9cAawaBD" />
+            <Link Id="KXBfdI7919lQWVqwo9wNjw" Ids="FiUJQUpXmLzPioaUJ4j9ty,NzrqkfKMU4BQaS518uQsr1" IsHidden="true" />
+            <Link Id="JYHp6upL35eOpeQPpkkciz" Ids="UzLconvNfdWP3vmu90EClF,RiDQHeSMrHtLddjxvamTX8" IsFeedback="true" />
+            <Link Id="Lf2RKsVKwpTNV3FjOCSE0D" Ids="S5Krt8cgq8cNTYU0Clt6KA,VQI7RSLrwn2M4Gk5VBsJLp" IsFeedback="true" />
+            <Link Id="I6vOsavKVXEOgPLzzVwapn" Ids="Eti8avnzVKKMMq6hmpYfGY,S5Krt8cgq8cNTYU0Clt6KA" />
+            <Link Id="U7hPU1luXE7LvNmrmNcqtR" Ids="UzLconvNfdWP3vmu90EClF,FkSNZhXiHArNbEO6GhkvkD" />
+            <Link Id="R45RZpFpfyNMlBUyhkqdbD" Ids="S5Krt8cgq8cNTYU0Clt6KA,FrqUYfTotWvL0UDtk9dW2C" />
+            <Link Id="IYJrWdMJSZbOmK6g3PUGya" Ids="VWE5PqHyLNVLGo8AlCzAtS,RiDQHeSMrHtLddjxvamTX8" />
+            <Link Id="M989TCRK7GkNjAHzix70k7" Ids="AF5XVch4mRIMXgWyQ0yTCH,BzRXHU6EWoDLCn1TtwUruJ" />
+            <Link Id="C3SGMAyc6yJMZJr35DSXh4" Ids="EhNDjnbLgMmLn9LnqxWke5,LC9zLM0OO79MBCz7ynTNxg" />
+            <Link Id="IW0IkXW30TPPIQcNqSApdC" Ids="L2EPooqm9JzPHU9cAawaBD,QBWNM61tJtSL6nCpRYyKUi" />
+            <Link Id="JaaKH0m2KlyMRChJeNmcPS" Ids="EkzsKLp8hg0OvNn5mIWloI,Uyrw0UhJJgUOlcI61N0JBo" IsFeedback="true" />
+            <Link Id="NzJ4S5sjjjyOXK9FniH2XL" Ids="EkzsKLp8hg0OvNn5mIWloI,AF5XVch4mRIMXgWyQ0yTCH" />
+            <Link Id="DZ8xGSNq4EyLoKbXyzDIiw" Ids="LC9zLM0OO79MBCz7ynTNxg,Uyrw0UhJJgUOlcI61N0JBo" />
+            <Link Id="I5ot1sm7gxgOAqYgrOiPCB" Ids="NzrqkfKMU4BQaS518uQsr1,TvZSvp1aPkvPZje6qyoZwL,R4IzBOCOnMUMrJvFv5BSqy" />
+            <Link Id="O3m46E2hzyEP7eLN7oFTls" Ids="NXvFxt07F8oOBlmJ3SbFwo,MurTNb5jVAbQbgo40TZSTB" />
+            <Link Id="EpRDYEpDydDM6TqxPY2Ea5" Ids="NzrqkfKMU4BQaS518uQsr1,MjkdkCVc4HDMXZEFqVD2QB" />
+            <Link Id="AwZFdaBKPPxOc7YGSuxsAy" Ids="MXrstwyY6wjLU0DXmElwRj,EkzsKLp8hg0OvNn5mIWloI" />
+            <Link Id="FeP4NaVcGsePTSyH6JlR4E" Ids="Uyrw0UhJJgUOlcI61N0JBo,UzLconvNfdWP3vmu90EClF" />
+            <Link Id="VOmOM892hExPCSRcGyfoeI" Ids="RiDQHeSMrHtLddjxvamTX8,NvTklT8DHr7ODHHXoygUhf" />
+          </Patch>
+        </Node>
+      </Canvas>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="L35yKJcHlshLHLnUpTIrZx">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <CategoryReference Kind="Category" Name="Primitive" />
+      </p:NodeReference>
+      <Patch Id="CVyeD2fgn0mNqduICr1Cs5">
+        <Canvas Id="DJs4g5PVM9iOLPFqS9nQ2N" CanvasType="Group" />
+        <Patch Id="IWgGI0yxJUyLGf8sTSQqMv" Name="Create" />
+        <Patch Id="EyC5bAGnBDfMR434Mcg7xP" Name="Update" />
+        <ProcessDefinition Id="GXnQflZtGL8OmkB6LK31iY">
+          <Fragment Id="Ah8AS9Vrd1jLqNODdpgKv6" Patch="IWgGI0yxJUyLGf8sTSQqMv" Enabled="true" />
+          <Fragment Id="KFHuadZ9B8uPwLtzrj1BL9" Patch="EyC5bAGnBDfMR434Mcg7xP" Enabled="true" />
+        </ProcessDefinition>
+      </Patch>
+    </Node>
+  </Patch>
+  <NugetDependency Id="LJokd9X1Ao3K9ZRKFffZWU" Location="VL.OpenCV" Version="0.0.0" />
+</Document>

--- a/VL.OpenCV.vl
+++ b/VL.OpenCV.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="AwLbD6sm3YSNSEVWaY0WST" LanguageVersion="2024.6.2" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="AwLbD6sm3YSNSEVWaY0WST" LanguageVersion="2024.6.6" Version="0.128">
   <Patch Id="C8nwPmC7mFvNATECRj2wt9">
     <Canvas Id="EatS5Y30OYxLELRQyBVMYE" DefaultCategory="OpenCV" CanvasType="FullCategory">
       <Canvas Id="N9r0bl4Ys0kMbfba5Gfahv" Name="Utils" Position="185,546" DefaultCategory="OpenCV.Utils">
@@ -21238,6 +21238,7 @@
                           <Pin Id="E6P8Jw0VgpAQaAV9vIVb1L" Name="Creator Call" Kind="InputPin" />
                           <Pin Id="E2X6U3iL7vKPEPd0Trw3ut" Name="Tracker" Kind="OutputPin" />
                         </Node>
+                        <Patch Id="VWOB2kRVfHsPK8id7fUOwd" Name="Dispose" />
                       </Patch>
                     </Node>
                     <Node Bounds="236,233,48,19" Id="PF64GTQnSx2N0bVzE2Ga6O">
@@ -26146,6 +26147,7 @@
                           </Node>
                         </Patch>
                       </Node>
+                      <Patch Id="AMWf9ZIGIdsPnJdy5Y6Lbh" Name="Dispose" />
                     </Patch>
                     <Pin Id="E4c7pfMH3QiN14878kLNcx" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="RHC1B4NRtGdLBZkQvhTWp9" Name="User Exceptions Channel" Kind="InputPin" IsHidden="true" />
@@ -38659,6 +38661,7 @@
                       <Choice Kind="TypeFlag" Name="Integer32" />
                     </p:TypeAnnotation>
                   </Pad>
+                  <Patch Id="DSOfwe3jeTjPzp8bFLsPCu" Name="Dispose" />
                 </Patch>
                 <Pin Id="IbLJTfqYhSsPvQIWUyMSUb" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="BuH5habZN4UNruJIkq2Clh" Name="Enabled" Kind="InputPin" DefaultValue="False">
@@ -46821,9 +46824,10 @@
   <PlatformDependency Id="UrxLbPlbKmVP94Zx5YWsQo" Location="System" />
   <PlatformDependency Id="KKd4psddv1PM1JDnyYS5Lv" Location="System.Drawing" />
   <PlatformDependency Id="Ee0UUmfqOVWPSXM6OSY7rA" Location="System.Windows.Forms" />
-  <NugetDependency Id="RhOWo82WyqnOWc3NKXTVr9" Location="VL.CoreLib" Version="2024.6.2" />
-  <NugetDependency Id="TwpzOT0OmmELnR6LDENtVA" Location="VL.CoreLib.Windows" Version="2024.6.2" />
+  <NugetDependency Id="RhOWo82WyqnOWc3NKXTVr9" Location="VL.CoreLib" Version="2024.6.6" />
+  <NugetDependency Id="TwpzOT0OmmELnR6LDENtVA" Location="VL.CoreLib.Windows" Version="2024.6.6" />
   <NugetDependency Id="F4rimzHBtAGLdwuyU70Lxy" Location="OpenCvSharp4.runtime.win" Version="4.9.0.20240103" />
   <NugetDependency Id="A13HOrTwDgsLxp65iajkZ3" Location="OpenCvSharp4" Version="4.9.0.20240103" />
   <NugetDependency Id="UB6TzvZX4ySQYuBmJI8qjp" Location="OpenCvSharp4.Extensions" Version="4.9.0.20240103" />
+  <DocumentDependency Id="QS33jD7hFfwLwnlsiXKRfV" Location="./VL.OpenCV.AddFrameDifference.vl" IsForward="true" />
 </Document>

--- a/help/Topics/Filter/Compare FrameDifference and FrameDifference(FilterEquals).vl
+++ b/help/Topics/Filter/Compare FrameDifference and FrameDifference(FilterEquals).vl
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="RL96cpmsqPhLakHfHltfSo" LanguageVersion="2024.6.6" Version="0.128">
+  <NugetDependency Id="NjKBgf3LaqCLvJskp0YE04" Location="VL.CoreLib" Version="2024.6.6" />
+  <Patch Id="AQKtKsFlzHgPDcwqouW18Y">
+    <Canvas Id="Cs3r1hFarjHQd7iyO9uuBP" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="MhxgUZ4LN13LLAENsvZtvL">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <CategoryReference Kind="Category" Name="Primitive" />
+      </p:NodeReference>
+      <Patch Id="Qr3eKJsJdEHP6htsc4AQuF">
+        <Canvas Id="PRn5XAUVZU0McRjsVZtp5h" CanvasType="Group">
+          <Node Bounds="154,220,125,19" Id="Q51ASYwxDuZQA4xCzKslpI">
+            <p:NodeReference LastCategoryFullName="OpenCV.Source" LastDependency="VL.OpenCV.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="VideoIn" />
+            </p:NodeReference>
+            <Pin Id="O6wn252v8OzQdU2Gj7AH6E" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="SYZb8HcsW1gPANWjIbloTD" Name="Video Input Device" Kind="InputPin" />
+            <Pin Id="B7TKccnxcalOj4sSiR2xnk" Name="Width" Kind="InputPin" />
+            <Pin Id="G2EPQIqAlv5Ocx4HMZ1ZkC" Name="Height" Kind="InputPin" />
+            <Pin Id="GKt4qqKa7BNOb2VwOX8pJR" Name="FPS" Kind="InputPin" />
+            <Pin Id="DizRwZuRuUAOJKoPiErq6n" Name="FourCC" Kind="InputPin" />
+            <Pin Id="Opk60mZhmguOXY55bWc0wz" Name="Show Properties" Kind="InputPin" />
+            <Pin Id="ECthuU8MId7LK90iwOTpNm" Name="Preferred API" Kind="InputPin" IsHidden="true" />
+            <Pin Id="OKth05uLLuRPWD2jhnP7On" Name="Video Acceleration" Kind="InputPin" IsHidden="true" />
+            <Pin Id="NFOjYJXA3CfOmAHUNFfNpA" Name="Hardware Device Index" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Q6WDESF24fALtOkOy0Nzz5" Name="Enabled" Kind="InputPin" />
+            <Pin Id="IluU3KeGH1jL4VrmzOfPKf" Name="Image" Kind="OutputPin" />
+            <Pin Id="OmnuyUfDQNNObGflzySpOO" Name="Supported Formats" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="154,345,91,19" Id="RiWY2dPyR40MLDBVIFo4az">
+            <p:NodeReference LastCategoryFullName="OpenCV.Filter" LastDependency="VL.OpenCV.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="Category" Name="Filter" NeedsToBeDirectParent="true" />
+              <Choice Kind="ProcessAppFlag" Name="FrameDifference" />
+            </p:NodeReference>
+            <Pin Id="A3H6lkTtqdMMrmQOlV4st4" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="NahVBFWx7J1LiC5KwO2kyn" Name="Input" Kind="InputPin" />
+            <Pin Id="JbpSfH95aIEQcqY7xrMmHY" Name="Apply" Kind="InputPin" />
+            <Pin Id="FelqzgaIbgBNaQwBMX3bhp" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="154,258,60,19" Id="GeZJ9Jb8CcENNPd1bl4rCj">
+            <p:NodeReference LastCategoryFullName="OpenCV.Filter" LastDependency="VL.OpenCV.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="GrayScale" />
+            </p:NodeReference>
+            <Pin Id="AQNijhErqdUNUmpk0S0SfB" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="H9fnsVyYgrlOG1EIJsRoiV" Name="Input" Kind="InputPin" />
+            <Pin Id="LaWu7HMTeDNMrF2sdB5lPj" Name="Source Format" Kind="InputPin" />
+            <Pin Id="UieKA1FgBbNLIdKlSURkfa" Name="Apply" Kind="InputPin" />
+            <Pin Id="NSxDwnZoe1LMl0L3utS0ER" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Pad Id="RdpDOwRPvD2PChu9BVH0vQ" Comment="" Bounds="156,435,190,132" ShowValueBox="true" isIOBox="true" />
+          <Pad Id="GGONwdjClbkOt9hovGFyQT" Comment="" Bounds="392,435,190,132" ShowValueBox="true" isIOBox="true" />
+          <Pad Id="TcLplUkHODHMzYXIYUPUYy" Bounds="400,399,269,19" ShowValueBox="true" isIOBox="true" Value=" FrameDifference (cached) remove flickering">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="KXjGmxGVoa8P0GrkQOLt72" Bounds="485,354,258,26" ShowValueBox="true" isIOBox="true" Value=" &lt;- FrameDifference (FilterEquals)">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Node Bounds="390,345,91,19" Id="NZEcBJav7MlLD1JxJVPkPV">
+            <p:NodeReference LastCategoryFullName="Main.Filter" LastDependency="VL.OpenCV.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="FrameDifference (FilterEquals)" />
+            </p:NodeReference>
+            <Pin Id="PJ2RWOSIZ88OaYng8LUM5p" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Tawibec6mDILrJtf2Q5Xpn" Name="Input" Kind="InputPin" />
+            <Pin Id="PPsY6bMihIINOFAvL7Ui8G" Name="FilterSameFrames" Kind="InputPin" IsHidden="true" />
+            <Pin Id="EPAvbSNnMe3Npnf1avlaq9" Name="Apply" Kind="InputPin" />
+            <Pin Id="QcuF3m2Vl3rQEq9t4we27L" Name="Output" Kind="OutputPin" />
+          </Node>
+        </Canvas>
+        <Patch Id="T5TLjDGSayMN1yskZ7VePc" Name="Create" />
+        <Patch Id="Th4w6E4XRqMPciTc6baztP" Name="Update" />
+        <ProcessDefinition Id="LDYn3kdy6OAO6kIdFJNlM9">
+          <Fragment Id="U2zR76ghqG1P17vI3mHbDq" Patch="T5TLjDGSayMN1yskZ7VePc" Enabled="true" />
+          <Fragment Id="CqpR84EIZzPNmVw5JcPjDY" Patch="Th4w6E4XRqMPciTc6baztP" Enabled="true" />
+        </ProcessDefinition>
+        <Link Id="Nhta7USChaqQZ9fLP3Vw5i" Ids="IluU3KeGH1jL4VrmzOfPKf,H9fnsVyYgrlOG1EIJsRoiV" />
+        <Link Id="VsmMndMG2gHMwmeC9LdllS" Ids="NSxDwnZoe1LMl0L3utS0ER,NahVBFWx7J1LiC5KwO2kyn" />
+        <Link Id="NeEUxzRxquVOxhQFSV2z5m" Ids="FelqzgaIbgBNaQwBMX3bhp,RdpDOwRPvD2PChu9BVH0vQ" />
+        <Link Id="SPymz5sizp5Ng166mawqf6" Ids="NSxDwnZoe1LMl0L3utS0ER,Tawibec6mDILrJtf2Q5Xpn" />
+        <Link Id="NoJaPeq408JPyOMTbJYaKi" Ids="QcuF3m2Vl3rQEq9t4we27L,GGONwdjClbkOt9hovGFyQT" />
+      </Patch>
+    </Node>
+  </Patch>
+  <NugetDependency Id="Hi4rZzMuONzNbS4uNvk3Gt" Location="VL.OpenCV" Version="0.0.0" />
+</Document>


### PR DESCRIPTION
# PR Details

<!--- A general summary of your changes -->
Adds a FrameDifference node that can filter out equal frames

## Description

<!--- Your changes in detail -->
When the speed of the Mainloop is faster than the speed of the frame grabber, it happens that FrameDifference is executed on the same frame and the output of FrameDifference is a black image.
The proposed node can avoid this behavior

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation
